### PR TITLE
Fix execution flags

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,7 @@ cp etc/initramfs-tools/scripts/init-bottom/root-ro /etc/initramfs-tools/scripts/
 chmod +x /etc/initramfs-tools/scripts/init-bottom/root-ro
 
 cp etc/initramfs-tools/hooks/root-ro /etc/initramfs-tools/hooks/root-ro
-chmod +x /etc/initramfs-tools/scripts/init-bottom/root-ro
+chmod +x /etc/initramfs-tools/hooks/root-ro
 
 echo Updating initramfs...
 update-initramfs -u


### PR DESCRIPTION
Set attributes to relevant file /etc/initramfs-tools/hooks/root-ro
Don't know if this is absolutely necessary. But you applied +x to the same file twice. Looks like a copy paste error.